### PR TITLE
Include the gauge name in the namespace

### DIFF
--- a/lambdas/query-metrics/src/main.rs
+++ b/lambdas/query-metrics/src/main.rs
@@ -102,7 +102,7 @@ async fn function_handler(_event: LambdaEvent<CloudWatchEvent>) -> Result<(), Er
 
                         let res = cloudwatch
                             .put_metric_data()
-                            .namespace(format!("DataLake/{name}"))
+                            .namespace(format!("DataLake/{name}/{}", &gauge.name))
                             .metric_data(datum)
                             .send()
                             .await?;


### PR DESCRIPTION
this results in metrics forwarded like
`datalake.<manifestkey>.<metricname>.<column>` = `<value>`